### PR TITLE
feat: add sops-deploy module

### DIFF
--- a/modules/sops-deploy/main.tf
+++ b/modules/sops-deploy/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
+  }
+}
+
+locals {
+  dest_folder = dirname(var.dest)
+}
+
+resource "terraform_data" "deploy" {
+  triggers_replace = concat([
+    var.user,
+    var.host
+  ], var.triggers)
+
+  connection {
+    type = "ssh"
+    user = var.user
+    host = var.host
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "[ -d ${local.dest_folder} ] || mkdir -p ${local.dest_folder}",
+    ]
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      [ -d ${path.module}/${self.id} ] || mkdir -p ${path.module}/${self.id}
+      sops --extract '${var.key}' -d ${var.path} > ${path.module}/${self.id}/key.txt
+    EOT
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/${self.id}/key.txt"
+    destination = var.dest
+  }
+
+  provisioner "local-exec" {
+    command = "rm -rf ${path.module}/${self.id}"
+  }
+}

--- a/modules/sops-deploy/outputs.tf
+++ b/modules/sops-deploy/outputs.tf
@@ -1,0 +1,4 @@
+output "id" {
+  value       = terraform_data.deploy.id
+  description = "Resource ID for use as trigger in dependent resources"
+}

--- a/modules/sops-deploy/variables.tf
+++ b/modules/sops-deploy/variables.tf
@@ -1,0 +1,32 @@
+variable "host" {
+  type        = string
+  description = "Target host to connect to"
+}
+
+variable "user" {
+  type        = string
+  default     = "root"
+  description = "SSH user to connect as"
+}
+
+variable "path" {
+  type        = string
+  description = "Path to sops-encrypted file"
+}
+
+variable "key" {
+  type        = string
+  description = "YAML key path to extract (e.g. '[\"age\"][\"key\"]')"
+}
+
+variable "dest" {
+  type        = string
+  default     = "/var/lib/sops-nix/key.txt"
+  description = "Destination path on target host"
+}
+
+variable "triggers" {
+  type        = list(string)
+  default     = []
+  description = "Additional triggers for secret replacement"
+}


### PR DESCRIPTION
## Summary
- Adds `sops-deploy` module for deploying sops-encrypted secrets to remote hosts
- Extracts secrets from sops files and transfers via SSH
- Provides `id` output for use as trigger in dependent resources

## Usage
```hcl
module "sops" {
  source   = "git::https://github.com/plumelo/nixtf.git//modules/sops-deploy"
  host     = "192.168.1.100"
  path     = "\${path.module}/secrets.yaml"
  key      = "[\"age\"][\"key\"]"
}
```