### PR TITLE
fix: append .config.system.build.toplevel to attribute

### DIFF
--- a/modules/nixos-deploy/main.tf
+++ b/modules/nixos-deploy/main.tf
@@ -12,7 +12,7 @@ module "sops" {
 
 module "derivation" {
   source        = "../nix-drv"
-  attribute     = var.attribute
+  attribute     = "${var.attribute}.config.system.build.toplevel"
   nix_options   = var.nix_options
   allow_unfree  = var.allow_unfree
   debug_logging = var.debug_logging


### PR DESCRIPTION
## Summary

nixos-deploy now accepts short form attribute like `.#nixosConfigurations.hostname` instead of requiring the full path `.#nixosConfigurations.hostname.config.system.build.toplevel`.

## Change

```hcl
# Before (manual)
attribute = ".#nixosConfigurations.myhost.config.system.build.toplevel"

# After (short form)
attribute = ".#nixosConfigurations.myhost"
```