### PR TITLE
Handle both short and full attribute formats for nixos-rebuild --flake

### DIFF
--- a/modules/nixos-deploy/main.tf
+++ b/modules/nixos-deploy/main.tf
@@ -1,3 +1,28 @@
+locals {
+  # Parse attribute into flake_path and attr_name
+  # Examples:
+  #   ".#flow" → flake_path=".", attr_name="flow"
+  #   "./formations/flow#flow" → flake_path="./formations/flow", attr_name="flow"
+  #   ".#nixosConfigurations.flow" → flake_path=".", attr_name="nixosConfigurations.flow"
+  parts      = split("#", var.attribute)
+  flake_path = length(local.parts) > 1 ? local.parts[0] : "."
+  attr_name  = length(local.parts) > 1 ? local.parts[1] : var.attribute
+
+  # Extract hostname from attr_name:
+  #   "nixosConfigurations.flow" → "flow"
+  #   "flow" → "flow"
+  hostname = coalesce(
+    try(regex("nixosConfigurations\\.([^\\.]+)", local.attr_name)[0], null),
+    local.attr_name
+  )
+
+  # Full attribute for nix-drv (derivation)
+  drv_attribute = "${local.flake_path}#nixosConfigurations.${local.hostname}.config.system.build.toplevel"
+
+  # Short attribute for nixos-rebuild --flake
+  flake_attribute = "${local.flake_path}#${local.hostname}"
+}
+
 module "sops" {
   count  = var.sops_file != null ? 1 : 0
   source = "../sops-deploy"
@@ -12,7 +37,7 @@ module "sops" {
 
 module "derivation" {
   source        = "../nix-drv"
-  attribute     = "${var.attribute}.config.system.build.toplevel"
+  attribute     = local.drv_attribute
   nix_options   = var.nix_options
   allow_unfree  = var.allow_unfree
   debug_logging = var.debug_logging
@@ -20,7 +45,7 @@ module "derivation" {
 
 module "deploy" {
   source      = "../nixos-rebuild"
-  attribute   = var.attribute
+  attribute   = local.flake_attribute
   target_host = var.target_host
   target_user = var.target_user
   sudo        = var.sudo

--- a/modules/nixos-deploy/variables.tf
+++ b/modules/nixos-deploy/variables.tf
@@ -1,6 +1,6 @@
 variable "attribute" {
   type        = string
-  description = "Nix flake attribute to deploy (e.g. '.#nixosConfigurations.hostname')"
+  description = "Nix flake attribute. Accepts '.#flow', './path#flow', or '.#nixosConfigurations.flow' - both formats work."
 }
 
 variable "target_host" {


### PR DESCRIPTION
Fixes #5

- Accept `.#flow`, `./path#flow`, or `.#nixosConfigurations.flow` as input
- Derive full attribute for nix-drv: `.#nixosConfigurations.flow.config.system.build.toplevel`
- Derive short attribute for nixos-rebuild --flake: `.#flow`

This allows users to pass either format and both modules work correctly.

The `nix-drv` module needs the full path including `nixosConfigurations`, while `nixos-rebuild --flake` needs just the hostname since it prepends `nixosConfigurations` internally.