### PR TITLE
feat: make SSH agent forwarding and identity agent configurable

### DIFF
--- a/modules/nixos-deploy/main.tf
+++ b/modules/nixos-deploy/main.tf
@@ -44,11 +44,13 @@ module "derivation" {
 }
 
 module "deploy" {
-  source      = "../nixos-rebuild"
-  attribute   = local.flake_attribute
-  target_host = var.target_host
-  target_user = var.target_user
-  sudo        = var.sudo
+  source         = "../nixos-rebuild"
+  attribute      = local.flake_attribute
+  target_host    = var.target_host
+  target_user    = var.target_user
+  sudo           = var.sudo
+  forward_agent  = var.forward_agent
+  identity_agent = var.identity_agent
   triggers = concat(
     [module.derivation.result.drv],
     var.sops_file != null ? [module.sops[0].id] : [],

--- a/modules/nixos-deploy/variables.tf
+++ b/modules/nixos-deploy/variables.tf
@@ -20,6 +20,18 @@ variable "sudo" {
   description = "Use sudo for remote commands"
 }
 
+variable "forward_agent" {
+  type        = bool
+  default     = false
+  description = "Enable SSH agent forwarding (-A) to the remote host."
+}
+
+variable "identity_agent" {
+  type        = bool
+  default     = true
+  description = "Pin the SSH agent socket via -o IdentityAgent. Only takes effect when SSH_AUTH_SOCK is set in the environment."
+}
+
 variable "allow_unfree" {
   type        = bool
   default     = false

--- a/modules/nixos-rebuild/main.tf
+++ b/modules/nixos-rebuild/main.tf
@@ -7,12 +7,21 @@ terraform {
   }
 }
 
+locals {
+  ssh_opts = join(" ", compact([
+    var.forward_agent ? "-A" : "",
+    var.identity_agent ? "$${SSH_AUTH_SOCK:+-o IdentityAgent=$$SSH_AUTH_SOCK}" : "",
+    "-o StrictHostKeyChecking=no",
+    "-o UserKnownHostsFile=/dev/null",
+  ]))
+}
+
 resource "terraform_data" "nixos_rebuild" {
   triggers_replace = var.triggers
 
   provisioner "local-exec" {
     command = <<-EOT
-      NIX_SSHOPTS="-A -o IdentityAgent=$SSH_AUTH_SOCK -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+      NIX_SSHOPTS="${local.ssh_opts}" \
         nixos-rebuild switch --no-reexec --flake ${var.attribute} --target-host ${var.target_user}@${var.target_host}${var.sudo ? " --sudo" : ""}
     EOT
   }

--- a/modules/nixos-rebuild/variables.tf
+++ b/modules/nixos-rebuild/variables.tf
@@ -14,6 +14,18 @@ variable "target_user" {
   description = "User to deploy as"
 }
 
+variable "forward_agent" {
+  type        = bool
+  default     = false
+  description = "Enable SSH agent forwarding (-A) to the remote host."
+}
+
+variable "identity_agent" {
+  type        = bool
+  default     = true
+  description = "Pin the SSH agent socket via -o IdentityAgent. Only takes effect when SSH_AUTH_SOCK is set in the environment."
+}
+
 variable "sudo" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Summary

- Replace hardcoded `-A -o IdentityAgent=$SSH_AUTH_SOCK` in `nixos-rebuild` with two configurable variables: `forward_agent` and `identity_agent`
- Fix SSH error when `SSH_AUTH_SOCK` is empty/unset — the `-o IdentityAgent=` (with empty value) causes SSH to fail
- Pass both variables through from `nixos-deploy` module

## Details

### New variables

| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `forward_agent` | `bool` | `false` | Controls the `-A` SSH flag for agent forwarding |
| `identity_agent` | `bool` | `true` | Controls `-o IdentityAgent=$SSH_AUTH_SOCK`, guarded with bash `${SSH_AUTH_SOCK:+...}` |

### How it works

The SSH options are now built dynamically using `compact`/`join`:

```hcl
locals {
  ssh_opts = join(" ", compact([
    var.forward_agent ? "-A" : "",
    var.identity_agent ? "$${SSH_AUTH_SOCK:+-o IdentityAgent=$$SSH_AUTH_SOCK}" : "",
    "-o StrictHostKeyChecking=no",
    "-o UserKnownHostsFile=/dev/null",
  ]))
}
```

- `identity_agent = true` (default): Uses bash parameter expansion `${SSH_AUTH_SOCK:+-o IdentityAgent=$SSH_AUTH_SOCK}` so the option is only added when `SSH_AUTH_SOCK` is actually set and non-empty
- `forward_agent = false` (default): Agent forwarding is off — not needed for standard `nixos-rebuild --target-host` deploys where all SSH is local→remote

### Bug fixed

Previously, when `SSH_AUTH_SOCK` was empty (e.g. in Terraform `local-exec` without agent), the command expanded to `-o IdentityAgent=` which is an SSH error. The bash guard `${SSH_AUTH_SOCK:+...}` prevents this.

## Affected modules

- `modules/nixos-rebuild` — new `locals` block, updated `local-exec` command, two new variables
- `modules/nixos-deploy` — passthrough of `forward_agent` and `identity_agent` to inner `nixos-rebuild` module